### PR TITLE
chore: improve dx scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
+    "build": "nx run-many --target=build --all",
     "dev": "npx concurrently \"nx run langchain:dev\" \"nx serve agentic-chat\""
   },
   "private": true,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "scripts": {
     "build": "nx run-many --target=build --all",
-    "dev": "npx concurrently \"nx run langchain:dev\" \"nx serve agentic-chat\""
+    "serve": "npx concurrently \"nx run langchain:dev\" \"nx serve agentic-chat\"",
+    "dev": "nx run-many --target=build --all && npx concurrently \"nx run langchain:dev\" \"nx serve agentic-chat\""
   },
   "private": true,
   "devDependencies": {


### PR DESCRIPTION
Improved DX by adding:

- `yarn build`: replaces `npx nx build @agentic-chat/utils && npx nx build @agentic-chat/tools && npx nx build @agentic-chat/graph && npx nx build langchain`

- `yarn dev`: build and serve, ensuring we always use the most up-to-date state of our local packages. Super speedy because nx caches the builds:

<img width="737" alt="Screenshot 2025-05-16 at 5 48 49 pm" src="https://github.com/user-attachments/assets/be2ec334-c93d-420f-b386-3c735a2b5b83" />

- `yarn serve`: just serves