### PR TITLE
chore: add reown app id

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,6 @@ VITE_PORTALS_BASE_URL=https://api.portals.fi
 VITE_PORTALS_API_KEY=copy me from web
 VITE_BEBOP_API_KEY=request me
 VITE_EVM_MNEMONIC=your seed here - for server testing only
-VITE_PROJECT_ID=request me, or create a reown cloud account (eventually will need to use ShapeShift's)
+
+# Reown cloud app ID
+VITE_PROJECT_ID=f3cf11a65c781d323d57f04018bccbe5


### PR DESCRIPTION
Adds a Reown project ID, managed by the same org as the web app and wallet.