### PR TITLE
feat: stategraph agent

### DIFF
--- a/graph/src/index.ts
+++ b/graph/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/graph';
+export * from './lib/clientGraph';

--- a/graph/src/lib/clientGraph.ts
+++ b/graph/src/lib/clientGraph.ts
@@ -1,0 +1,70 @@
+/**
+ * Starter LangGraph.js Template
+ * Make this code your own!
+ */
+import {  ToolNode } from '@langchain/langgraph/prebuilt';
+import { ChatOpenAI } from '@langchain/openai';
+import { tokensSearch, bebopRate, EvmKit } from '@agentic-chat/tools';
+import { SYSTEM_PROMPT } from '@agentic-chat/utils';
+import { END, MemorySaver, MessagesAnnotation, START, StateGraph } from '@langchain/langgraph/web';
+import { WalletClient } from 'viem';
+import { AIMessage, SystemMessage } from "@langchain/core/messages";
+import { RunnableLambda } from "@langchain/core/runnables";
+
+// @ts-expect-error TODO: FIXME maybe
+const env = import.meta?.env ? import.meta.env : process.env;
+
+const model = new ChatOpenAI({
+  modelName: 'gpt-4o-mini',
+  temperature: 0,
+  openAIApiKey: env.VITE_OPENAI_API_KEY,
+});
+
+
+// Adds persistence
+const checkpointer = new MemorySaver();
+
+function shouldContinue(state: typeof MessagesAnnotation.State): "action" | typeof END {
+  const lastMessage = state.messages[state.messages.length - 1];
+  // If there is no function call, then we finish
+  if (lastMessage && !(lastMessage as AIMessage).tool_calls?.length) {
+      return END;
+  }
+  // Otherwise if there is, we continue
+  return "action";
+}
+
+export const makeDynamicGraph = (walletClient: WalletClient | undefined) => {
+  const tools = [tokensSearch, bebopRate, ...new EvmKit(walletClient).getTools()];
+  const modelWithTools = model.bindTools(tools);
+  const toolNode = new ToolNode(tools);
+
+  // Create a prompt runnable that will prepend the system message
+  const promptRunnable = RunnableLambda.from(
+    (state: typeof MessagesAnnotation.State) => {
+      return [new SystemMessage(SYSTEM_PROMPT), ...state.messages];
+    }
+  );
+
+  // Pipe the prompt runnable into the model
+  const modelRunnable = promptRunnable.pipe(modelWithTools);
+
+  async function callModel(state: typeof MessagesAnnotation.State): Promise<Partial<typeof MessagesAnnotation.State>> {
+    const response = await modelRunnable.invoke(state);
+    return { messages: [response] };
+  }
+
+  const graph = new StateGraph(MessagesAnnotation)
+    .addNode("agent", callModel)
+    .addNode("action", toolNode)
+    .addConditionalEdges(
+      "agent",
+      shouldContinue
+    )
+    .addEdge("action", "agent")
+    .addEdge(START, "agent");
+
+  return graph.compile({
+    checkpointer,
+  });
+}


### PR DESCRIPTION
### Description 

Moves both client and server graphs to `StateGraph` instead of prebuilt agent. Prepares for streaming in a follow-up, and makes things more evolutive, since we'll now be in control of the graph ourselves vs. the prebuilt one locking us in a certain graph (where we won't be able to support streaming).

### Testing

Do a quick test of this with https://agentchat.vercel.app and webapp side by side and ensure both work just the same as before.

### Issue

- closes https://github.com/shapeshift/agentic-chat/issues/24

### Screenshots

https://jam.dev/c/594bcc6b-ee5a-42b8-a482-0fd9305e3854

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":""}
```
-->
