### PR TITLE
feat: precalculate user facing crytpo and currency values, migrate ma…

### DIFF
--- a/apps/agentic-server/package.json
+++ b/apps/agentic-server/package.json
@@ -23,7 +23,7 @@
     "@mastra/loggers": "^0.10.12",
     "@mastra/memory": "^0.15.2",
     "axios": "^1.11.0",
-    "mathjs": "^14.7.0",
+    "expr-eval": "^2.0.2",
     "zod": "*"
   },
   "devDependencies": {

--- a/apps/agentic-server/src/mastra/agents/shapeshiftAgent.ts
+++ b/apps/agentic-server/src/mastra/agents/shapeshiftAgent.ts
@@ -14,15 +14,17 @@ export const shapeshiftAgent = new Agent({
 
     **Core Rules:**
     - Always confirm network if not specified by user
-    - Convert all crypto amounts from base units using mathCalculator tool
+    - Use precalculated humanReadableValue and usdValue from portfolio tool for display
+    - For ANY addition, subtraction, multiplication, or division: MUST use mathCalculator tool
+    - Never perform manual arithmetic - always use mathCalculator for calculations
     - Never display caip10/caip19 IDs - show human names only
     - Preserve exact decimal precision from tool outputs (never round/truncate)
     - Use markdown formatting for all responses
 
     **Tool Usage:**
     - **getAssets**: Find assets by name/symbol, get prices and market data
-    - **mathCalculator**: Convert base unit balances to readable format (e.g. "781573210609912 / (10 ^ 18)")
-    - **portfolio**: Get user balances for specified network (requires network + address)
+    - **mathCalculator**: Use for all arithmetic operations to ensure precision
+    - **portfolio**: Get user balances with human-readable values and USD amounts (requires network + address)
     - **initiateSwap**: Execute full swap flow (rates + allowances + transactions to wallet)
 
     **Swap Workflow:**

--- a/apps/agentic-server/src/mastra/tools/mathCalculatorTool.ts
+++ b/apps/agentic-server/src/mastra/tools/mathCalculatorTool.ts
@@ -1,19 +1,15 @@
 import { createTool } from '@mastra/core'
-import { create, all } from 'mathjs'
+import { Parser } from 'expr-eval'
 import z from 'zod'
 
-// Create math.js instance configured for BigNumber with high precision
-const math = create(all, {
-  number: 'BigNumber', // Use BigNumber by default
-  precision: 64, // 64 significant digits for high precision
-})
+// Create expr-eval parser instance
+const parser = new Parser()
 
 // Safety constants to prevent DoS attacks
 const MAX_EXPRESSION_LENGTH = 1000
 const DANGEROUS_PATTERNS = [
   /\^[^)]*\d{4,}/, // Exponentials with huge exponents (e.g., 10^10000)
-  /\d{1000,}/, // Numbers with 10+ consecutive digits
-  /!/, // factorials
+  /\d{1000,}/, // Numbers with 1000+ consecutive digits
 ]
 
 export const mathCalculatorInput = z.object({
@@ -31,7 +27,7 @@ export type MathCalculatorOutput = z.infer<typeof mathCalculatorOutput>
 
 export const mathCalculatorTool = createTool({
   id: 'mathCalculator',
-  description: 'Convert crypto amounts from base units to human-readable format',
+  description: 'Perform mathematical calculations with high precision',
   inputSchema: mathCalculatorInput,
   outputSchema: mathCalculatorOutput,
   execute: ({ context, mastra }) => {
@@ -53,14 +49,14 @@ export const mathCalculatorTool = createTool({
         }
       }
 
-      // Evaluate the expression using math.js with BigNumber precision
-      const rawResult = math.evaluate(expression)
+      // Evaluate the expression using expr-eval
+      const rawResult = parser.evaluate(expression)
 
       // Convert result to string format
       let result: string
       if (precision !== undefined) {
         // Apply specific precision if requested
-        result = math.format(rawResult, { precision })
+        result = Number(rawResult).toFixed(precision)
       } else {
         // Use default string representation
         result = String(rawResult)

--- a/apps/agentic-server/src/mastra/tools/portfolioTool.ts
+++ b/apps/agentic-server/src/mastra/tools/portfolioTool.ts
@@ -1,4 +1,5 @@
 import { createTool } from '@mastra/core'
+import { fromBaseUnit, calculateUsdValue } from '@shapeshiftoss/utils'
 import z from 'zod'
 
 import { getAssetsTool } from './asset'
@@ -19,8 +20,11 @@ const portfolioToolOutput = z.object({
         name: z.string(),
         symbol: z.string(),
         precision: z.number(),
+        price: z.string(),
       }),
-      value: z.string().describe('Asset balance value'),
+      value: z.string().describe('Asset balance value in base units'),
+      humanReadableValue: z.string().describe('Asset balance in human-readable format'),
+      usdValue: z.string().describe('Asset balance value in USD'),
     })
   ),
 })
@@ -30,7 +34,7 @@ export type PortfolioToolOutput = z.infer<typeof portfolioToolOutput>
 
 export const portfolioTool = createTool({
   id: 'portfolioTool',
-  description: 'Get user crypto balances for a specific network',
+  description: 'Get user crypto balances with human-readable values and USD amounts for a specific network',
   inputSchema: portfolioToolInput,
   outputSchema: portfolioToolOutput,
   execute: async ({ context, mastra, runtimeContext }) => {
@@ -52,19 +56,28 @@ export const portfolioTool = createTool({
       runtimeContext,
     })
 
-    // Step 3: Combine data
+    // Step 3: Combine data and calculate human-readable values
     return {
       account,
       chainId,
-      balances: assets.map(asset => ({
-        asset: {
-          assetId: asset.assetId,
-          name: asset.name,
-          symbol: asset.symbol,
-          precision: asset.precision,
-        },
-        value: balances[asset.assetId] || '0',
-      })),
+      balances: assets.map(asset => {
+        const baseUnitValue = balances[asset.assetId] || '0'
+        const humanReadableValue = fromBaseUnit(baseUnitValue, asset.precision)
+        const usdValue = calculateUsdValue(humanReadableValue, asset.price)
+
+        return {
+          asset: {
+            assetId: asset.assetId,
+            name: asset.name,
+            symbol: asset.symbol,
+            precision: asset.precision,
+            price: asset.price,
+          },
+          value: baseUnitValue,
+          humanReadableValue,
+          usdValue,
+        }
+      }),
     }
   },
 })

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -36,6 +36,21 @@ export const toBaseUnit = (value: string | number | BigNumber, precision: number
   return bn.multipliedBy(new BigNumber(10).pow(precision)).dp(0).toString()
 }
 
+export const calculateUsdValue = (humanReadableAmount: string, price: string): string => {
+  try {
+    const amount = new BigNumber(humanReadableAmount)
+    const priceNum = new BigNumber(price)
+
+    if (amount.isZero() || priceNum.isZero() || priceNum.isNaN()) {
+      return '0.00'
+    }
+
+    return amount.multipliedBy(priceNum).toFixed(2)
+  } catch {
+    return '0.00'
+  }
+}
+
 export const getUnchainedHttpUrlEnvVar = (chainId: ChainId): string => {
   switch (chainId) {
     case ethChainId:

--- a/yarn.lock
+++ b/yarn.lock
@@ -675,13 +675,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.26.10":
-  version: 7.28.4
-  resolution: "@babel/runtime@npm:7.28.4"
-  checksum: 10/6c9a70452322ea80b3c9b2a412bcf60771819213a67576c8cec41e88a95bb7bf01fc983754cda35dc19603eef52df22203ccbf7777b9d6316932f9fb77c25163
-  languageName: node
-  linkType: hard
-
 "@babel/template@npm:^7.27.2":
   version: 7.27.2
   resolution: "@babel/template@npm:7.27.2"
@@ -5240,8 +5233,8 @@ __metadata:
     "@mastra/loggers": "npm:^0.10.12"
     "@mastra/memory": "npm:^0.15.2"
     axios: "npm:^1.11.0"
+    expr-eval: "npm:^2.0.2"
     mastra: "npm:^0.13.0"
-    mathjs: "npm:^14.7.0"
     zod: "npm:*"
   languageName: unknown
   linkType: soft
@@ -8017,13 +8010,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"complex.js@npm:^2.2.5":
-  version: 2.4.2
-  resolution: "complex.js@npm:2.4.2"
-  checksum: 10/089257e0f09b3c9f52b4f7e009abb762a924d820fe01002da61bf9a3cee28c364a77de4d26ba8623c4fac017feb6856797da0713f8c165f795914be0c9e0b127
-  languageName: node
-  linkType: hard
-
 "concat-map@npm:0.0.1":
   version: 0.0.1
   resolution: "concat-map@npm:0.0.1"
@@ -8350,13 +8336,6 @@ __metadata:
   version: 1.2.0
   resolution: "decamelize@npm:1.2.0"
   checksum: 10/ad8c51a7e7e0720c70ec2eeb1163b66da03e7616d7b98c9ef43cce2416395e84c1e9548dd94f5f6ffecfee9f8b94251fc57121a8b021f2ff2469b2bae247b8aa
-  languageName: node
-  linkType: hard
-
-"decimal.js@npm:^10.4.3":
-  version: 10.6.0
-  resolution: "decimal.js@npm:10.6.0"
-  checksum: 10/c0d45842d47c311d11b38ce7ccc911121953d4df3ebb1465d92b31970eb4f6738a065426a06094af59bee4b0d64e42e7c8984abd57b6767c64ea90cf90bb4a69
   languageName: node
   linkType: hard
 
@@ -9077,13 +9056,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escape-latex@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "escape-latex@npm:1.2.0"
-  checksum: 10/73a787319f0965ecb8244bb38bf3a3cba872f0b9a5d3da8821140e9f39fe977045dc953a62b1a2bed4d12bfccbe75a7d8ec786412bf00739eaa2f627d0a8e0d6
-  languageName: node
-  linkType: hard
-
 "escape-string-regexp@npm:^4.0.0":
   version: 4.0.0
   resolution: "escape-string-regexp@npm:4.0.0"
@@ -9605,6 +9577,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expr-eval@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "expr-eval@npm:2.0.2"
+  checksum: 10/b603f1ed2423636d84fd9984ed47af5cf90b42139faf5c535a778a12e916347b1e722364e3946ff3fc59537e01ea2eb3b4c3cc32a47bf80a097d1796e0b56fa6
+  languageName: node
+  linkType: hard
+
 "express-rate-limit@npm:^7.5.0":
   version: 7.5.1
   resolution: "express-rate-limit@npm:7.5.1"
@@ -10009,13 +9988,6 @@ __metadata:
   version: 4.3.7
   resolution: "fraction.js@npm:4.3.7"
   checksum: 10/bb5ebcdeeffcdc37b68ead3bdfc244e68de188e0c64e9702197333c72963b95cc798883ad16adc21588088b942bca5b6a6ff4aeb1362d19f6f3b629035dc15f5
-  languageName: node
-  linkType: hard
-
-"fraction.js@npm:^5.2.1":
-  version: 5.3.4
-  resolution: "fraction.js@npm:5.3.4"
-  checksum: 10/ef2c4bc81b2484065f8f7e4c2498f3fdfe6d233b8e7c7f75e3683ed10698536129b2c2dbd6c3f788ca4a020ec07116dd909a91036a364c98dc802b5003bfc613
   languageName: node
   linkType: hard
 
@@ -11123,13 +11095,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"javascript-natural-sort@npm:^0.7.1":
-  version: 0.7.1
-  resolution: "javascript-natural-sort@npm:0.7.1"
-  checksum: 10/7bf6eab67871865d347f09a95aa770f9206c1ab0226bcda6fdd9edec340bf41111a7f82abac30556aa16a21cfa3b2b1ca4a362c8b73dd5ce15220e5d31f49d79
-  languageName: node
-  linkType: hard
-
 "jiti@npm:^2.4.2":
   version: 2.4.2
   resolution: "jiti@npm:2.4.2"
@@ -11772,25 +11737,6 @@ __metadata:
   version: 1.1.0
   resolution: "math-intrinsics@npm:1.1.0"
   checksum: 10/11df2eda46d092a6035479632e1ec865b8134bdfc4bd9e571a656f4191525404f13a283a515938c3a8de934dbfd9c09674d9da9fa831e6eb7e22b50b197d2edd
-  languageName: node
-  linkType: hard
-
-"mathjs@npm:^14.7.0":
-  version: 14.7.0
-  resolution: "mathjs@npm:14.7.0"
-  dependencies:
-    "@babel/runtime": "npm:^7.26.10"
-    complex.js: "npm:^2.2.5"
-    decimal.js: "npm:^10.4.3"
-    escape-latex: "npm:^1.2.0"
-    fraction.js: "npm:^5.2.1"
-    javascript-natural-sort: "npm:^0.7.1"
-    seedrandom: "npm:^3.0.5"
-    tiny-emitter: "npm:^2.1.0"
-    typed-function: "npm:^4.2.1"
-  bin:
-    mathjs: bin/cli.js
-  checksum: 10/b1a46bef9c27dea7261fd6ad0ff33f128e5dfa19c9c20211b1119bed2710f70caa50c136b7c830fe73532d414449f8bd43c53f6b7ffcb1b25627d18bd1d60a4f
   languageName: node
   linkType: hard
 
@@ -14632,13 +14578,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"seedrandom@npm:^3.0.5":
-  version: 3.0.5
-  resolution: "seedrandom@npm:3.0.5"
-  checksum: 10/acad5e516c04289f61c2fb9848f449b95f58362b75406b79ec51e101ec885293fc57e3675d2f39f49716336559d7190f7273415d185fead8cd27b171ebf7d8fb
-  languageName: node
-  linkType: hard
-
 "semver@npm:^6.3.1":
   version: 6.3.1
   resolution: "semver@npm:6.3.1"
@@ -15387,13 +15326,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tiny-emitter@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "tiny-emitter@npm:2.1.0"
-  checksum: 10/75633f4de4f47f43af56aff6162f25b87be7efc6f669fda256658f3c3f4a216f23dc0d13200c6fafaaf1b0c7142f0201352fb06aec0b77f68aea96be898f4516
-  languageName: node
-  linkType: hard
-
 "tinybench@npm:^2.9.0":
   version: 2.9.0
   resolution: "tinybench@npm:2.9.0"
@@ -15633,13 +15565,6 @@ __metadata:
     possible-typed-array-names: "npm:^1.0.0"
     reflect.getprototypeof: "npm:^1.0.6"
   checksum: 10/d6b2f0e81161682d2726eb92b1dc2b0890890f9930f33f9bcf6fc7272895ce66bc368066d273e6677776de167608adc53fcf81f1be39a146d64b630edbf2081c
-  languageName: node
-  linkType: hard
-
-"typed-function@npm:^4.2.1":
-  version: 4.2.1
-  resolution: "typed-function@npm:4.2.1"
-  checksum: 10/2218d6e4a56c414c2d9c1e3cf2f0d26d6a8848d3e875cbd0eec5a791c25c4ee182cb488a6077b45b110334de7bd7f44fb049feac9e5216bef3172c22acbbf501
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This task has two parts. Firstly we want to minimise the amount of maths the LLM has to do. For example, it regularly has to convert base units to human readable crypto amounts and also use that number multiplied by price to get USD value. 

We want to precalculate these values and attach them to tool outputs where we can so the LLM can use them. This will make it faster and more reliable.

While we're at it, i've migrated to a more lightweight math tool. Currently we use mathjs which is hectic (5mb). Let's switch to expr-eval