### PR TITLE
fix: fetching ui showing undefined network temporarily

### DIFF
--- a/apps/agentic-chat/src/components/assistant-ui/GetAssets.tsx
+++ b/apps/agentic-chat/src/components/assistant-ui/GetAssets.tsx
@@ -11,8 +11,8 @@ type GetAssetsContentProps = Omit<ToolCallMessagePartProps<GetAssetsInput, GetAs
 const GetAssetsContent: React.FC<GetAssetsContentProps> = ({ args, status, result, isError }) => {
   const assetDetailsText = (() => {
     const parts = ['asset details']
-    if (args.searchTerm) parts.push(`for ${args.searchTerm}`)
-    if (args.network) parts.push(`on ${args.network}`)
+    if (args.searchTerm !== undefined) parts.push(`for ${args.searchTerm}`)
+    if (args.network !== undefined) parts.push(`on ${args.network}`)
     return parts.join(' ')
   })()
 

--- a/apps/agentic-chat/src/components/assistant-ui/Portfolio.tsx
+++ b/apps/agentic-chat/src/components/assistant-ui/Portfolio.tsx
@@ -11,7 +11,7 @@ type PortfolioContentProps = Omit<ToolCallMessagePartProps<PortfolioToolInput, P
 const PortfolioContent: React.FC<PortfolioContentProps> = ({ status, result, args, isError }) => {
   const porfolioDetailsText = (() => {
     const parts = ['portfolio details']
-    if (args.network) {
+    if (args.network !== undefined) {
       parts.push(`on ${args.network}`)
     }
     return parts.join(' ')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured asset descriptions are displayed whenever provided, preventing them from being skipped due to falsy values like empty strings.
  * Corrected network detail rendering to show “on {network}” only when the network is explicitly defined, avoiding unintended omissions or displays.
  * Improved consistency of asset and portfolio detail presentation across views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->