### PR TITLE
feat: add send tool

### DIFF
--- a/apps/agentic-chat/src/components/toolUIRegistry.tsx
+++ b/apps/agentic-chat/src/components/toolUIRegistry.tsx
@@ -7,6 +7,7 @@ import { GetAssetsUI } from './tools/GetAssetsUI'
 import { GetTransactionHistoryUI } from './tools/GetTransactionHistoryUI'
 import { InitiateSwapUI } from './tools/InitiateSwapUI'
 import { PortfolioUI } from './tools/PortfolioUI'
+import { SendUI } from './tools/SendUI'
 import { SwitchNetworkUI } from './tools/SwitchNetworkUI'
 
 interface ToolUIProps {
@@ -24,6 +25,7 @@ export const TOOL_UI_REGISTRY: Record<string, ToolUIComponent> = {
   getAccountTool: GetAccountUI,
   getTransactionHistoryTool: GetTransactionHistoryUI,
   getAllowanceTool: GetAllowanceUI,
+  sendTool: SendUI,
 } as const
 
 export function getToolUIComponent(toolName: string): ToolUIComponent | undefined {

--- a/apps/agentic-chat/src/components/tools/SendUI.tsx
+++ b/apps/agentic-chat/src/components/tools/SendUI.tsx
@@ -1,0 +1,118 @@
+import { useAppKitAccount } from '@reown/appkit/react'
+import type { SendOutput } from '@shapeshiftoss/agentic-server'
+
+import { StepStatus, useSendExecution } from '@/hooks/useSendExecution'
+import { firstFourLastFour } from '@/lib/utils'
+import { useToolExecutionStore } from '@/stores/toolExecutionStore'
+
+import { Skeleton } from '../ui/skeleton'
+import { TxStepCard } from '../ui/TxStepCard'
+
+import type { ToolUIComponentProps } from './toolUIHelpers'
+
+export function SendUI({ toolPart }: ToolUIComponentProps) {
+  const { state, output, toolCallId } = toolPart
+  const sendOutput = output as SendOutput | undefined
+  const { isHistorical, getPersistedState } = useToolExecutionStore()
+  const { address } = useAppKitAccount()
+
+  const sendData = state === 'output-available' && sendOutput ? sendOutput : null
+  const { error, steps, networkName } = useSendExecution(toolCallId, state, sendData)
+
+  const isHistoricalSkipped = isHistorical(toolCallId) && !getPersistedState(toolCallId)
+
+  if (isHistoricalSkipped) {
+    return (
+      <TxStepCard.Root>
+        <div className="text-sm text-muted-foreground font-medium p-4">⏭️ Send execution skipped (no saved data)</div>
+      </TxStepCard.Root>
+    )
+  }
+
+  const [preparationStep, networkStep, sendStep] = steps
+  if (!preparationStep || !networkStep || !sendStep) {
+    return null
+  }
+
+  const completedCount = [preparationStep.status, networkStep.status, sendStep.status].filter(
+    s => s === StepStatus.COMPLETE || s === StepStatus.SKIPPED
+  ).length
+
+  const footerMessage = (() => {
+    if (state === 'output-error') return { type: 'error' as const, text: 'Failed to prepare send transaction' }
+    if (error) return { type: 'error' as const, text: `Send failed: ${error}` }
+    return null
+  })()
+
+  const summary = sendOutput?.summary
+
+  return (
+    <TxStepCard.Root>
+      <TxStepCard.Header>
+        <TxStepCard.HeaderRow>
+          {address && (
+            <div className="text-xs text-muted-foreground font-normal">Sent from {firstFourLastFour(address)}</div>
+          )}
+          <div className="text-sm text-muted-foreground font-normal">
+            {summary?.estimatedFeeUsd ? summary.estimatedFeeUsd : <Skeleton className="h-5 w-16" />}
+          </div>
+        </TxStepCard.HeaderRow>
+        <TxStepCard.HeaderRow>
+          {summary ? (
+            <div className="text-lg font-semibold">Send {summary.asset}</div>
+          ) : (
+            <Skeleton className="h-7 w-40" />
+          )}
+          {summary ? (
+            <TxStepCard.Amount>
+              -{summary.amount} {summary.symbol}
+            </TxStepCard.Amount>
+          ) : (
+            <Skeleton className="h-7 w-32" />
+          )}
+        </TxStepCard.HeaderRow>
+      </TxStepCard.Header>
+
+      {summary && (
+        <TxStepCard.Content>
+          <TxStepCard.Details>
+            <TxStepCard.DetailItem label="From" value={summary.from} />
+            <TxStepCard.DetailItem label="To" value={summary.to} />
+            <TxStepCard.DetailItem label="Amount" value={summary.asset} />
+            <TxStepCard.DetailItem label="Network" value={summary.chainName} />
+            <TxStepCard.DetailItem
+              label="Estimated Fee"
+              value={`${summary.estimatedFeeCrypto} ${summary.estimatedFeeSymbol}`}
+            />
+            {summary.ataCreation && (
+              <TxStepCard.DetailItem
+                label="Note"
+                value="Will create recipient token account (~0.002 SOL)"
+                className="text-amber-600"
+              />
+            )}
+          </TxStepCard.Details>
+        </TxStepCard.Content>
+      )}
+
+      <TxStepCard.Stepper completedCount={completedCount} totalCount={3}>
+        <TxStepCard.Step status={preparationStep.status} connectorBottom>
+          Preparing send transaction
+        </TxStepCard.Step>
+        <TxStepCard.Step status={networkStep.status} connectorTop connectorBottom>
+          {networkName ? `Switch to ${networkName}` : 'Switch network'}
+        </TxStepCard.Step>
+        <TxStepCard.Step status={sendStep.status} connectorTop>
+          Sign and send transaction
+        </TxStepCard.Step>
+        {footerMessage && (
+          <div
+            className={`text-sm font-medium mt-4 ${footerMessage.type === 'error' ? 'text-red-500' : 'text-muted-foreground'}`}
+          >
+            {footerMessage.text}
+          </div>
+        )}
+      </TxStepCard.Stepper>
+    </TxStepCard.Root>
+  )
+}

--- a/apps/agentic-chat/src/hooks/useNetworkSwitch.ts
+++ b/apps/agentic-chat/src/hooks/useNetworkSwitch.ts
@@ -2,7 +2,7 @@ import type { AppKitNetwork } from '@reown/appkit/networks'
 import { arbitrum, avalanche, base, bsc, gnosis, mainnet, optimism, polygon, solana } from '@reown/appkit/networks'
 import { modal } from '@reown/appkit/react'
 import type { SwitchNetworkOutput } from '@shapeshiftoss/agentic-server'
-import { useRef } from 'react'
+import { useEffect, useRef } from 'react'
 
 import type { PersistedToolState } from '@/stores/toolExecutionStore'
 import { useToolExecutionStore } from '@/stores/toolExecutionStore'
@@ -80,15 +80,24 @@ export const useNetworkSwitch = (
   const store = useToolExecutionStore()
 
   const hasHydratedRef = useRef(false)
-  if (!hasHydratedRef.current && !store.toolStates.has(toolCallId)) {
-    const persisted = store.getPersistedState(toolCallId)
-    if (persisted) {
-      const hydratedState = persistedStateToNetworkState(persisted)
-      store.initializeState(toolCallId, hydratedState)
-      store.markExecuted(toolCallId)
-      hasHydratedRef.current = true
+  const lastToolCallIdRef = useRef<string | undefined>(undefined)
+  useEffect(() => {
+    // Reset hydration flag when toolCallId changes
+    if (lastToolCallIdRef.current !== toolCallId) {
+      hasHydratedRef.current = false
+      lastToolCallIdRef.current = toolCallId
     }
-  }
+
+    if (!hasHydratedRef.current && !store.toolStates.has(toolCallId)) {
+      const persisted = store.getPersistedState(toolCallId)
+      if (persisted) {
+        const hydratedState = persistedStateToNetworkState(persisted)
+        store.initializeState(toolCallId, hydratedState)
+        store.markExecuted(toolCallId)
+        hasHydratedRef.current = true
+      }
+    }
+  }, [toolCallId, store])
 
   const { state } = useToolExecutionEffect(
     toolCallId,

--- a/apps/agentic-chat/src/hooks/useSendExecution.ts
+++ b/apps/agentic-chat/src/hooks/useSendExecution.ts
@@ -1,0 +1,244 @@
+import { useAppKitProvider } from '@reown/appkit/react'
+import type { SendOutput } from '@shapeshiftoss/agentic-server'
+import { CHAIN_NAMESPACE, fromChainId } from '@shapeshiftoss/caip'
+import type { DynamicToolUIPart } from 'ai'
+import { useEffect, useRef } from 'react'
+import { useSwitchChain } from 'wagmi'
+
+import type { PersistedToolState } from '@/stores/toolExecutionStore'
+import { useToolExecutionStore } from '@/stores/toolExecutionStore'
+import type { SolanaWalletProvider } from '@/utils/chains/types'
+import { executeSend } from '@/utils/sendExecutor'
+
+import { useToolExecutionEffect } from './useToolExecutionEffect'
+
+type SendData = SendOutput
+
+export enum SendStep {
+  PREPARATION = 0,
+  NETWORK_SWITCH = 1,
+  SEND = 2,
+  COMPLETE = 3,
+}
+
+export enum StepStatus {
+  NOT_STARTED = 'not_started',
+  IN_PROGRESS = 'in_progress',
+  COMPLETE = 'complete',
+  SKIPPED = 'skipped',
+  FAILED = 'failed',
+}
+
+interface SendState {
+  currentStep: SendStep
+  completedSteps: Set<SendStep>
+  sendTxHash?: string
+  error?: string
+  failedStep?: SendStep
+}
+
+const initialSendState: SendState = {
+  currentStep: SendStep.PREPARATION,
+  completedSteps: new Set(),
+}
+
+const getStepStatus = (step: SendStep, state: SendState): StepStatus => {
+  if (state.failedStep === step) return StepStatus.FAILED
+  if (state.currentStep < step) return StepStatus.NOT_STARTED
+  if (state.currentStep === step && !state.error) return StepStatus.IN_PROGRESS
+  if (state.completedSteps.has(step)) return StepStatus.COMPLETE
+  return StepStatus.SKIPPED
+}
+
+function sendStateToPersistedState(toolCallId: string, state: SendState, networkName?: string): PersistedToolState {
+  const phases: string[] = []
+
+  if (state.completedSteps.has(SendStep.PREPARATION)) {
+    phases.push('preparation_complete')
+  }
+  if (state.completedSteps.has(SendStep.NETWORK_SWITCH)) {
+    phases.push('network_switched')
+  }
+  if (state.completedSteps.has(SendStep.SEND)) {
+    phases.push('send_complete')
+  }
+  if (state.error) {
+    phases.push('error')
+  }
+
+  return {
+    toolCallId,
+    phases,
+    meta: {
+      ...(state.sendTxHash && { sendTxHash: state.sendTxHash }),
+      ...(state.error && { error: state.error }),
+      ...(state.failedStep !== undefined && { failedStep: state.failedStep }),
+      ...(networkName && { networkName }),
+    },
+  }
+}
+
+function persistedStateToSendState(persisted: PersistedToolState): SendState {
+  const completedSteps = new Set<SendStep>()
+  let currentStep = SendStep.COMPLETE
+
+  if (persisted.phases.includes('preparation_complete')) {
+    completedSteps.add(SendStep.PREPARATION)
+  }
+  if (persisted.phases.includes('network_switched')) {
+    completedSteps.add(SendStep.NETWORK_SWITCH)
+  }
+  if (persisted.phases.includes('send_complete')) {
+    completedSteps.add(SendStep.SEND)
+  }
+
+  return {
+    currentStep,
+    completedSteps,
+    sendTxHash: persisted.meta.sendTxHash as string | undefined,
+    error: persisted.meta.error as string | undefined,
+    failedStep: persisted.meta.failedStep as SendStep | undefined,
+  }
+}
+
+export interface SendStepInfo {
+  step: SendStep
+  status: StepStatus
+}
+
+interface UseSendExecutionResult {
+  steps: SendStepInfo[]
+  networkName?: string
+  error?: string
+  sendTxHash?: string
+}
+
+export const useSendExecution = (
+  toolCallId: string,
+  toolState: DynamicToolUIPart['state'],
+  sendData: SendData | null
+): UseSendExecutionResult => {
+  const { switchChainAsync } = useSwitchChain()
+  const { walletProvider } = useAppKitProvider('solana')
+  const solanaProvider = walletProvider as SolanaWalletProvider | undefined
+  const store = useToolExecutionStore()
+
+  const hasHydratedRef = useRef(false)
+  const lastToolCallIdRef = useRef<string | undefined>(undefined)
+  useEffect(() => {
+    // Reset hydration flag when toolCallId changes
+    if (lastToolCallIdRef.current !== toolCallId) {
+      hasHydratedRef.current = false
+      lastToolCallIdRef.current = toolCallId
+    }
+
+    if (!hasHydratedRef.current && !store.toolStates.has(toolCallId)) {
+      const persisted = store.getPersistedState(toolCallId)
+      if (persisted) {
+        const hydratedState = persistedStateToSendState(persisted)
+        store.initializeState(toolCallId, hydratedState)
+        store.markExecuted(toolCallId)
+        hasHydratedRef.current = true
+      }
+    }
+  }, [toolCallId, store])
+
+  const { state } = useToolExecutionEffect(
+    toolCallId,
+    sendData,
+    initialSendState,
+    async (data, setState) => {
+      let sendTxHash: string | undefined
+
+      try {
+        const { tx } = data
+
+        const assetChainId = data.sendData.chainId
+        const { chainNamespace, chainReference } = fromChainId(assetChainId)
+
+        // Step 0: Preparation (completed by this point)
+        setState(draft => {
+          draft.completedSteps.add(SendStep.PREPARATION)
+          draft.currentStep = SendStep.NETWORK_SWITCH
+          draft.error = undefined
+        })
+
+        // Step 1: Network Switch
+        // Non-EVM: no wallet network switch needed; skip step
+        if (chainNamespace !== CHAIN_NAMESPACE.Evm) {
+          setState(draft => {
+            draft.completedSteps.add(SendStep.NETWORK_SWITCH)
+            draft.currentStep = (draft.currentStep + 1) as SendStep
+            draft.error = undefined
+          })
+        } else {
+          // EVM: always switch to the chain to avoid race conditions
+          const chainIdNumber = Number(chainReference)
+          await switchChainAsync({ chainId: chainIdNumber })
+          setState(draft => {
+            draft.completedSteps.add(draft.currentStep)
+            draft.currentStep = (draft.currentStep + 1) as SendStep
+            draft.error = undefined
+          })
+        }
+
+        // Step 2: Send
+        sendTxHash = await executeSend(tx, { solanaProvider })
+
+        // Build final state with all completed steps
+        let finalCompletedSteps = new Set(state.completedSteps)
+        finalCompletedSteps.add(SendStep.PREPARATION)
+        finalCompletedSteps.add(SendStep.SEND)
+
+        setState(draft => {
+          draft.sendTxHash = sendTxHash
+          draft.completedSteps.add(draft.currentStep)
+          draft.currentStep = SendStep.COMPLETE
+          draft.error = undefined
+        })
+
+        // Save terminal state with actual accumulated completedSteps
+        const finalState: SendState = {
+          currentStep: SendStep.COMPLETE,
+          completedSteps: finalCompletedSteps,
+          sendTxHash,
+        }
+        const persisted = sendStateToPersistedState(toolCallId, finalState, data.sendData.asset.network)
+        store.savePersistedState(persisted)
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error)
+        let errorState: SendState | undefined
+        setState(draft => {
+          draft.error = errorMessage
+          draft.failedStep = draft.currentStep
+          errorState = { ...draft }
+        })
+
+        // Save error state
+        if (errorState) {
+          const persisted = sendStateToPersistedState(toolCallId, errorState, data.sendData.asset.network)
+          store.savePersistedState(persisted)
+        }
+      }
+    },
+    [switchChainAsync, solanaProvider, toolCallId]
+  )
+
+  const preparationStepStatus = (() => {
+    if (toolState === 'output-error') return StepStatus.FAILED
+    if (toolState === 'input-streaming' || toolState === 'input-available') return StepStatus.IN_PROGRESS
+    if (toolState === 'output-available') return StepStatus.COMPLETE
+    return StepStatus.NOT_STARTED
+  })()
+
+  return {
+    steps: [
+      { step: SendStep.PREPARATION, status: preparationStepStatus },
+      { step: SendStep.NETWORK_SWITCH, status: getStepStatus(SendStep.NETWORK_SWITCH, state) },
+      { step: SendStep.SEND, status: getStepStatus(SendStep.SEND, state) },
+    ],
+    networkName: sendData?.sendData?.asset?.network,
+    error: state.error,
+    sendTxHash: state.sendTxHash,
+  }
+}

--- a/apps/agentic-chat/src/hooks/useSwapExecution.ts
+++ b/apps/agentic-chat/src/hooks/useSwapExecution.ts
@@ -2,7 +2,7 @@ import { useAppKitProvider } from '@reown/appkit/react'
 import type { InitiateSwapOutput } from '@shapeshiftoss/agentic-server'
 import { CHAIN_NAMESPACE, fromChainId } from '@shapeshiftoss/caip'
 import type { DynamicToolUIPart } from 'ai'
-import { useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import { useSwitchChain } from 'wagmi'
 
 import type { PersistedToolState } from '@/stores/toolExecutionStore'
@@ -136,15 +136,24 @@ export const useSwapExecution = (
   const store = useToolExecutionStore()
 
   const hasHydratedRef = useRef(false)
-  if (!hasHydratedRef.current && !store.toolStates.has(toolCallId)) {
-    const persisted = store.getPersistedState(toolCallId)
-    if (persisted) {
-      const hydratedState = persistedStateToSwapState(persisted)
-      store.initializeState(toolCallId, hydratedState)
-      store.markExecuted(toolCallId)
-      hasHydratedRef.current = true
+  const lastToolCallIdRef = useRef<string | undefined>(undefined)
+  useEffect(() => {
+    // Reset hydration flag when toolCallId changes
+    if (lastToolCallIdRef.current !== toolCallId) {
+      hasHydratedRef.current = false
+      lastToolCallIdRef.current = toolCallId
     }
-  }
+
+    if (!hasHydratedRef.current && !store.toolStates.has(toolCallId)) {
+      const persisted = store.getPersistedState(toolCallId)
+      if (persisted) {
+        const hydratedState = persistedStateToSwapState(persisted)
+        store.initializeState(toolCallId, hydratedState)
+        store.markExecuted(toolCallId)
+        hasHydratedRef.current = true
+      }
+    }
+  }, [toolCallId, store])
 
   const { state } = useToolExecutionEffect(
     toolCallId,

--- a/apps/agentic-chat/src/utils/sendExecutor.ts
+++ b/apps/agentic-chat/src/utils/sendExecutor.ts
@@ -1,0 +1,43 @@
+import type { SendOutput } from '@shapeshiftoss/agentic-server'
+import { hexToBigInt } from 'viem'
+
+import type { SolanaWalletProvider } from '@/utils/chains/types'
+import { sendTransaction } from '@/utils/sendTransaction'
+
+type TransactionData = SendOutput['tx']
+
+interface ExecuteTransactionOptions {
+  solanaProvider?: SolanaWalletProvider
+}
+
+async function executeTransaction(tx: TransactionData, options?: ExecuteTransactionOptions) {
+  const gasLimit = tx.gasLimit
+    ? typeof tx.gasLimit === 'string' && tx.gasLimit.startsWith('0x')
+      ? Number(hexToBigInt(tx.gasLimit as `0x${string}`))
+      : Number(tx.gasLimit)
+    : undefined
+
+  const finalTx = {
+    chainId: tx.chainId,
+    data: tx.data,
+    from: tx.from,
+    to: tx.to,
+    value: tx.value,
+    ...(gasLimit !== undefined && { gasLimit }),
+    ...(options?.solanaProvider && { solanaProvider: options.solanaProvider }),
+  }
+
+  return sendTransaction(finalTx)
+}
+
+export async function executeSend(sendTx: TransactionData, options?: ExecuteTransactionOptions): Promise<string> {
+  try {
+    return await executeTransaction(sendTx, options)
+  } catch (error) {
+    const message =
+      error instanceof Error && error.message?.includes('User rejected')
+        ? 'Send cancelled by user'
+        : `Send failed: ${error instanceof Error ? error.message : String(error)}`
+    throw new Error(message)
+  }
+}

--- a/apps/agentic-server/src/index.ts
+++ b/apps/agentic-server/src/index.ts
@@ -61,3 +61,4 @@ export {
   type SwitchNetworkInput,
   type SwitchNetworkOutput,
 } from './tools/switchNetwork'
+export { sendTool, executeSend, type SendInput, type SendOutput } from './tools/send'

--- a/apps/agentic-server/src/lib/schemas/sendSchemas.ts
+++ b/apps/agentic-server/src/lib/schemas/sendSchemas.ts
@@ -1,0 +1,49 @@
+import { asset } from '@shapeshiftoss/types'
+import * as z from 'zod'
+
+import { assetInputSchema, transactionSchema } from './swapSchemas'
+
+// Send input schema
+export const sendSchema = z.object({
+  asset: assetInputSchema.describe('Asset to send (e.g., ETH, USDC, SOL)'),
+  recipient: z.string().describe('Recipient wallet address'),
+  amount: z.string().describe('Amount in crypto tokens, or "max" for maximum balance'),
+})
+
+// Send summary schema for user-facing information
+export const sendSummarySchema = z.object({
+  asset: z.string(),
+  symbol: z.string(),
+  amount: z.string(),
+  from: z.string(),
+  to: z.string(),
+  network: z.string(),
+  chainName: z.string(),
+  estimatedFeeCrypto: z.string(),
+  estimatedFeeSymbol: z.string(),
+  estimatedFeeUsd: z.string().optional(),
+  ataCreation: z.boolean().optional(), // Solana-specific
+})
+
+// Send data schema for internal use
+export const sendDataSchema = z.object({
+  assetId: z.string(),
+  from: z.string(),
+  to: z.string(),
+  amount: z.string(),
+  chainId: z.string(),
+  asset: asset,
+})
+
+// Core send output schema
+export const sendOutputSchema = z.object({
+  summary: sendSummarySchema,
+  tx: transactionSchema,
+  sendData: sendDataSchema,
+})
+
+// Export type definitions
+export type SendInput = z.infer<typeof sendSchema>
+export type SendSummary = z.infer<typeof sendSummarySchema>
+export type SendData = z.infer<typeof sendDataSchema>
+export type SendOutput = z.infer<typeof sendOutputSchema>

--- a/apps/agentic-server/src/routes/chat.ts
+++ b/apps/agentic-server/src/routes/chat.ts
@@ -21,6 +21,7 @@ import { getTransactionHistoryTool } from '../tools/getTransactionHistory'
 import { initiateSwapTool, initiateSwapUsdTool } from '../tools/initiateSwap'
 import { mathCalculator } from '../tools/mathCalculator'
 import { portfolioTool } from '../tools/portfolio'
+import { sendTool } from '../tools/send'
 import { switchNetworkTool } from '../tools/switchNetwork'
 import type { WalletContext } from '../utils/walletContextSimple'
 
@@ -126,6 +127,14 @@ function buildTools(walletContext: WalletContext) {
       execute: (args: Parameters<typeof switchNetworkTool.execute>[0]) => {
         console.log('[Tool] switchNetworkTool:', JSON.stringify(args, null, 2))
         return switchNetworkTool.execute(args)
+      },
+    },
+    sendTool: {
+      description: sendTool.description,
+      inputSchema: sendTool.inputSchema,
+      execute: async (args: Parameters<typeof sendTool.execute>[0]) => {
+        console.log('[Tool] sendTool:', JSON.stringify(args, null, 2))
+        return sendTool.execute(args, walletContext)
       },
     },
   }

--- a/apps/agentic-server/src/tools/initiateSwap.ts
+++ b/apps/agentic-server/src/tools/initiateSwap.ts
@@ -1,21 +1,23 @@
 import { fromAssetId } from '@shapeshiftoss/caip'
 import type { Asset, GetRateOutput } from '@shapeshiftoss/types'
-import { chainIdToNetwork } from '@shapeshiftoss/types'
-import { fromBaseUnit, toBaseUnit } from '@shapeshiftoss/utils'
-import { PublicKey } from '@solana/web3.js'
+import { toBaseUnit } from '@shapeshiftoss/utils'
 import { encodeFunctionData, erc20Abi, getAddress } from 'viem'
 import { z } from 'zod'
 
 import { assetInputSchema } from '../lib/schemas/swapSchemas'
 import type { AssetInput, swapPreparationSchema } from '../lib/schemas/swapSchemas'
 import { getAllowance } from '../utils'
-import { isEvmChain, isSolanaChain } from '../utils/chains/helpers'
+import { validateAddress } from '../utils/addressValidation'
+import { resolveAsset } from '../utils/assetHelpers'
+import { validateSufficientBalance } from '../utils/balanceHelpers'
+import { isEvmChain } from '../utils/chains/helpers'
 import { getBebopRate } from '../utils/getBebopRate'
 import { getRelayRate } from '../utils/getRelayRate'
+import { networkToFeeSymbol } from '../utils/networkHelpers'
+import { createTransaction } from '../utils/transactionHelpers'
 import { getAddressForChain } from '../utils/walletContextSimple'
 import type { WalletContext } from '../utils/walletContextSimple'
 
-import { executeGetAccount } from './getAccount'
 import { executeGetAssetsBasic } from './getAssets'
 
 interface ResolvedAssets {
@@ -23,57 +25,21 @@ interface ResolvedAssets {
   buyAsset: Asset
 }
 
-function createTransaction(tx: {
-  chainId: string | number
-  data: string
-  from: string
-  to: string
-  value: string
-  gasLimit?: string
-}) {
-  return {
-    chainId: String(tx.chainId),
-    data: tx.data || '',
-    from: tx.from,
-    to: tx.to,
-    value: tx.value,
-    ...(tx.gasLimit && { gasLimit: tx.gasLimit }),
-  }
-}
-
 async function resolveSwapAssets(sellAssetInput: AssetInput, buyAssetInput: AssetInput): Promise<ResolvedAssets> {
   // If only one network is specified, default to same-chain swap
-  const sellNetwork = sellAssetInput.network || buyAssetInput.network
-  const buyNetwork = buyAssetInput.network || sellAssetInput.network
+  const sellInputWithNetwork = {
+    ...sellAssetInput,
+    network: sellAssetInput.network || buyAssetInput.network,
+  }
+  const buyInputWithNetwork = {
+    ...buyAssetInput,
+    network: buyAssetInput.network || sellAssetInput.network,
+  }
 
-  const [buyAssetsResult, sellAssetsResult] = await Promise.all([
-    executeGetAssetsBasic({ searchTerm: buyAssetInput.symbolOrName, network: buyNetwork }),
-    executeGetAssetsBasic({ searchTerm: sellAssetInput.symbolOrName, network: sellNetwork }),
+  const [sellAsset, buyAsset] = await Promise.all([
+    resolveAsset(sellInputWithNetwork),
+    resolveAsset(buyInputWithNetwork),
   ])
-
-  if (sellAssetsResult.assets.length === 0) {
-    throw new Error(
-      `No asset found for "${sellAssetInput.symbolOrName}"${sellAssetInput.network ? ` on ${sellAssetInput.network}` : ''}`
-    )
-  }
-  if (sellAssetsResult.assets.length > 1) {
-    throw new Error(`Multiple assets found for "${sellAssetInput.symbolOrName}". Please be more specific.`)
-  }
-  if (buyAssetsResult.assets.length === 0) {
-    throw new Error(
-      `No asset found for "${buyAssetInput.symbolOrName}"${buyAssetInput.network ? ` on ${buyAssetInput.network}` : ''}`
-    )
-  }
-  if (buyAssetsResult.assets.length > 1) {
-    throw new Error(`Multiple assets found for "${buyAssetInput.symbolOrName}". Please be more specific.`)
-  }
-
-  const sellAsset = sellAssetsResult.assets[0]
-  const buyAsset = buyAssetsResult.assets[0]
-
-  if (!sellAsset || !buyAsset) {
-    throw new Error('Could not resolve sell or buy asset')
-  }
 
   return { sellAsset, buyAsset }
 }
@@ -192,18 +158,6 @@ function createSwapSummary(sellAsset: Asset, buyAsset: Asset, sellAmount: string
       ? (((parseFloat(buyEstimatedValueUSD) - parseFloat(sellValueUSD)) / parseFloat(sellValueUSD)) * 100).toFixed(2)
       : null
 
-  const networkToFeeSymbol: Record<string, string> = {
-    ethereum: 'ETH',
-    optimism: 'ETH',
-    arbitrum: 'ETH',
-    base: 'ETH',
-    polygon: 'POL',
-    avalanche: 'AVAX',
-    bsc: 'BNB',
-    gnosis: 'xDAI',
-    solana: 'SOL',
-  }
-
   const feeSymbol = networkToFeeSymbol[sellAsset.network] || sellAsset.symbol.toUpperCase()
 
   return {
@@ -255,21 +209,8 @@ async function executeSwapInternal({
   const sellAddress = getAddressForChain(walletContext, sellAsset.chainId)
   const buyAddress = getAddressForChain(walletContext, buyAsset.chainId)
 
-  if (isSolanaChain(sellAsset.chainId)) {
-    try {
-      new PublicKey(sellAddress)
-    } catch {
-      throw new Error(`Invalid Solana address for sell asset: ${sellAddress}`)
-    }
-  }
-
-  if (isSolanaChain(buyAsset.chainId)) {
-    try {
-      new PublicKey(buyAddress)
-    } catch {
-      throw new Error(`Invalid Solana address for buy asset: ${buyAddress}`)
-    }
-  }
+  validateAddress(sellAddress, sellAsset.chainId)
+  validateAddress(buyAddress, buyAsset.chainId)
 
   const bestRate = await fetchBestSwapRate(sellAddress, buyAddress, sellAsset, buyAsset, sellAmountCrypto)
 
@@ -282,20 +223,7 @@ async function executeSwapInternal({
 
   const needsApproval = allowanceData.isApprovalRequired
 
-  const accountData = await executeGetAccount({
-    account: sellAddress,
-    network: chainIdToNetwork[sellAsset.chainId] ?? 'ethereum',
-  })
-
-  const userBalance = accountData.balances[sellAsset.assetId] || '0'
-  const sellAmountBaseUnit = toBaseUnit(sellAmountCrypto, sellAsset.precision)
-
-  if (BigInt(userBalance) < BigInt(sellAmountBaseUnit)) {
-    const availableAmount = fromBaseUnit(userBalance, sellAsset.precision)
-    throw new Error(
-      `Insufficient ${sellAsset.symbol} balance. Required: ${sellAmountCrypto}, Available: ${availableAmount}`
-    )
-  }
+  await validateSufficientBalance(sellAddress, sellAsset, sellAmountCrypto)
 
   const approvalTx = buildApprovalTransaction(
     needsApproval,

--- a/apps/agentic-server/src/tools/send.ts
+++ b/apps/agentic-server/src/tools/send.ts
@@ -1,0 +1,127 @@
+import type { Asset } from '@shapeshiftoss/types'
+
+import type { SendInput, SendOutput, SendSummary } from '../lib/schemas/sendSchemas'
+import { sendSchema } from '../lib/schemas/sendSchemas'
+import type { TransactionData } from '../lib/schemas/swapSchemas'
+import { validateAddress } from '../utils/addressValidation'
+import { isNativeToken, resolveAsset } from '../utils/assetHelpers'
+import { getBalance, validateSufficientBalance } from '../utils/balanceHelpers'
+import { isEvmChain, isSolanaChain } from '../utils/chains/helpers'
+import { calculateMaxSendAmount, formatEstimatedFee } from '../utils/feeEstimation'
+import { networkToFeeSymbol } from '../utils/networkHelpers'
+import { buildEvmNativeTransfer, buildEvmTokenTransfer, buildSolanaTransfer } from '../utils/transactionHelpers'
+import { getAddressForChain } from '../utils/walletContextSimple'
+import type { WalletContext } from '../utils/walletContextSimple'
+
+const SOLANA_RPC_URL = (() => {
+  const url = process.env.VITE_SOLANA_RPC_URL
+  if (!url) {
+    throw new Error('VITE_SOLANA_RPC_URL environment variable is required')
+  }
+  return url
+})()
+
+export async function executeSend(input: SendInput, walletContext?: WalletContext): Promise<SendOutput> {
+  console.log('[send]:', input)
+
+  // 1. Resolve asset
+  const asset = await resolveAsset(input.asset)
+
+  // 2. Get sender address
+  const from = getAddressForChain(walletContext, asset.chainId)
+
+  // 3. Validate recipient address
+  validateAddress(input.recipient, asset.chainId)
+
+  // 4. Get balance and calculate send amount (handle "max")
+  const balance = await getBalance(from, asset)
+
+  let sendAmount: string
+  if (input.amount.toLowerCase() === 'max') {
+    sendAmount = await calculateMaxSendAmount(asset, balance, from, input.recipient)
+  } else {
+    // Validate amount
+    if (!Number.isFinite(parseFloat(input.amount)) || parseFloat(input.amount) <= 0) {
+      throw new Error('Amount must be a positive number')
+    }
+    sendAmount = input.amount
+
+    // Check balance
+    await validateSufficientBalance(from, asset, sendAmount)
+  }
+
+  // 5. Build transaction
+  const txResult = await buildSendTransaction(asset, from, input.recipient, sendAmount)
+
+  // 6. Create summary
+  const summary = createSendSummary(asset, from, input.recipient, sendAmount, txResult)
+
+  return {
+    summary,
+    tx: txResult.tx,
+    sendData: {
+      assetId: asset.assetId,
+      from,
+      to: input.recipient,
+      amount: sendAmount,
+      chainId: asset.chainId,
+      asset,
+    },
+  }
+}
+
+async function buildSendTransaction(
+  asset: Asset,
+  from: string,
+  to: string,
+  amount: string
+): Promise<{ tx: TransactionData; needsAtaCreation?: boolean }> {
+  if (isEvmChain(asset.chainId)) {
+    const tx = isNativeToken(asset)
+      ? buildEvmNativeTransfer(asset, from, to, amount)
+      : buildEvmTokenTransfer(asset, from, to, amount)
+    return { tx }
+  } else if (isSolanaChain(asset.chainId)) {
+    const result = await buildSolanaTransfer(asset, from, to, amount, SOLANA_RPC_URL)
+    return { tx: result, needsAtaCreation: result.needsAtaCreation }
+  }
+
+  throw new Error(`Unsupported chain: ${asset.chainId}`)
+}
+
+function createSendSummary(
+  asset: Asset,
+  from: string,
+  to: string,
+  amount: string,
+  txResult: { tx: TransactionData; needsAtaCreation?: boolean }
+): SendSummary {
+  const assetPrice = parseFloat(asset.price || '0')
+  const valueUSD = assetPrice > 0 ? `$${(parseFloat(amount) * assetPrice).toFixed(2)}` : undefined
+
+  const feeSymbol = networkToFeeSymbol[asset.network] || asset.symbol.toUpperCase()
+  const estimatedFeeCrypto = formatEstimatedFee(asset.chainId, isNativeToken(asset), txResult.needsAtaCreation)
+
+  return {
+    asset: `${amount} ${asset.symbol.toUpperCase()}`,
+    symbol: asset.symbol.toUpperCase(),
+    amount,
+    from: `${from.slice(0, 6)}...${from.slice(-4)}`,
+    to: `${to.slice(0, 6)}...${to.slice(-4)}`,
+    network: asset.network,
+    chainName: asset.network,
+    estimatedFeeCrypto,
+    estimatedFeeSymbol: feeSymbol,
+    estimatedFeeUsd: valueUSD,
+    ...(txResult.needsAtaCreation && { ataCreation: true }),
+  }
+}
+
+export const sendTool = {
+  description:
+    'Send cryptocurrency to a recipient address. Supports native tokens (ETH, SOL, MATIC, etc.) and tokens (ERC20, SPL). Use "max" for amount to send maximum balance after fees.',
+  inputSchema: sendSchema,
+  execute: executeSend,
+}
+
+export type { SendInput, SendOutput }

--- a/apps/agentic-server/src/utils/addressValidation.ts
+++ b/apps/agentic-server/src/utils/addressValidation.ts
@@ -1,0 +1,29 @@
+import { PublicKey } from '@solana/web3.js'
+import { getAddress, isAddress } from 'viem'
+
+import { isEvmChain, isSolanaChain } from './chains/helpers'
+
+export function validateAddress(address: string, chainId: string): void {
+  if (isEvmChain(chainId)) {
+    validateEvmAddress(address)
+  } else if (isSolanaChain(chainId)) {
+    validateSolanaAddress(address)
+  } else {
+    throw new Error(`Unsupported chain: ${chainId}`)
+  }
+}
+
+export function validateEvmAddress(address: string): void {
+  if (!isAddress(address)) {
+    throw new Error(`Invalid EVM address: ${address}`)
+  }
+  getAddress(address)
+}
+
+export function validateSolanaAddress(address: string): void {
+  try {
+    new PublicKey(address)
+  } catch {
+    throw new Error(`Invalid Solana address: ${address}`)
+  }
+}

--- a/apps/agentic-server/src/utils/assetHelpers.ts
+++ b/apps/agentic-server/src/utils/assetHelpers.ts
@@ -1,0 +1,36 @@
+import type { Asset } from '@shapeshiftoss/types'
+import { getFeeAssetIdByChainId } from '@shapeshiftoss/utils'
+
+import type { AssetInput } from '../lib/schemas/swapSchemas'
+import { executeGetAssetsBasic } from '../tools/getAssets'
+
+export async function resolveAsset(assetInput: AssetInput): Promise<Asset> {
+  const assetsResult = await executeGetAssetsBasic({
+    searchTerm: assetInput.symbolOrName,
+    network: assetInput.network,
+  })
+
+  if (assetsResult.assets.length === 0) {
+    throw new Error(
+      `No asset found for "${assetInput.symbolOrName}"${assetInput.network ? ` on ${assetInput.network}` : ''}`
+    )
+  }
+
+  if (assetsResult.assets.length > 1) {
+    const symbols = assetsResult.assets.map(a => `${a.symbol} (${a.name})`).join(', ')
+    throw new Error(
+      `Multiple assets found for "${assetInput.symbolOrName}": ${symbols}. Please be more specific or specify a network.`
+    )
+  }
+
+  const asset = assetsResult.assets[0]
+  if (!asset) {
+    throw new Error(`Unexpected error: asset not found in results`)
+  }
+
+  return asset
+}
+
+export function isNativeToken(asset: Asset): boolean {
+  return asset.assetId === getFeeAssetIdByChainId(asset.chainId)
+}

--- a/apps/agentic-server/src/utils/balanceHelpers.ts
+++ b/apps/agentic-server/src/utils/balanceHelpers.ts
@@ -1,0 +1,24 @@
+import type { Asset } from '@shapeshiftoss/types'
+import { chainIdToNetwork } from '@shapeshiftoss/types'
+import { fromBaseUnit, toBaseUnit } from '@shapeshiftoss/utils'
+
+import { executeGetAccount } from '../tools/getAccount'
+
+export async function getBalance(address: string, asset: Asset): Promise<string> {
+  const network = chainIdToNetwork[asset.chainId] ?? 'ethereum'
+  const accountData = await executeGetAccount({
+    account: address,
+    network,
+  })
+  return accountData.balances[asset.assetId] || '0'
+}
+
+export async function validateSufficientBalance(address: string, asset: Asset, requiredAmount: string): Promise<void> {
+  const balance = await getBalance(address, asset)
+  const requiredAmountBaseUnit = toBaseUnit(requiredAmount, asset.precision)
+
+  if (BigInt(balance) < BigInt(requiredAmountBaseUnit)) {
+    const available = fromBaseUnit(balance, asset.precision)
+    throw new Error(`Insufficient ${asset.symbol} balance. Required: ${requiredAmount}, Available: ${available}`)
+  }
+}

--- a/apps/agentic-server/src/utils/chains/helpers.ts
+++ b/apps/agentic-server/src/utils/chains/helpers.ts
@@ -9,3 +9,11 @@ export const isSolanaChain = (chainId: string): boolean => {
   const { chainNamespace } = fromChainId(chainId)
   return chainNamespace === CHAIN_NAMESPACE.Solana
 }
+
+/**
+ * Check if chain supports transaction operations (send, swap, etc.)
+ * Currently only EVM and Solana chains are supported
+ */
+export const supportsTxOperations = (chainId: string): boolean => {
+  return isEvmChain(chainId) || isSolanaChain(chainId)
+}

--- a/apps/agentic-server/src/utils/feeEstimation.ts
+++ b/apps/agentic-server/src/utils/feeEstimation.ts
@@ -1,0 +1,170 @@
+import { fromAssetId, fromChainId } from '@shapeshiftoss/caip'
+import type { Asset } from '@shapeshiftoss/types'
+import { fromBaseUnit, getViemClient } from '@shapeshiftoss/utils'
+import { getAssociatedTokenAddressSync } from '@solana/spl-token'
+import { Connection, PublicKey } from '@solana/web3.js'
+
+import { isNativeToken } from './assetHelpers'
+import { supportsTxOperations } from './chains/helpers'
+
+const SOLANA_RPC_URL = (() => {
+  const url = process.env.VITE_SOLANA_RPC_URL
+  if (!url) {
+    throw new Error('VITE_SOLANA_RPC_URL environment variable is required')
+  }
+  return url
+})()
+
+// Solana constants (in lamports)
+const SOLANA_RENT_EXEMPT_MINIMUM = 890880n // Minimum rent-exempt balance
+const SOLANA_BASE_FEE = 5000n // Typical transaction fee
+const SOLANA_ATA_CREATION_COST = 2039280n // Cost to create Associated Token Account
+
+// EVM constants
+const EVM_NATIVE_GAS_LIMIT = 21000n // Standard ETH transfer
+const EVM_ERC20_GAS_LIMIT = 65000n // ERC20 transfer estimate
+const GAS_PRICE_BUFFER_PERCENT = 20n // 20% buffer for gas price fluctuations
+
+export async function calculateMaxSendAmount(
+  asset: Asset,
+  balance: string,
+  from: string,
+  recipient: string
+): Promise<string> {
+  if (!supportsTxOperations(asset.chainId)) {
+    throw new Error(`Send operations are only supported for EVM and Solana chains`)
+  }
+
+  const { chainNamespace } = fromChainId(asset.chainId)
+
+  if (chainNamespace === 'eip155') {
+    return calculateMaxEvmSend(asset, balance)
+  }
+
+  return calculateMaxSolanaSend(asset, balance, from, recipient)
+}
+
+async function calculateMaxEvmSend(asset: Asset, balance: string): Promise<string> {
+  const isNative = isNativeToken(asset)
+
+  if (!isNative) {
+    // ERC20: Can send full balance (gas paid in native token)
+    return fromBaseUnit(balance, asset.precision)
+  }
+
+  // Native token: Must reserve gas
+  const viemClient = getViemClient(asset.chainId)
+  const gasPrice = await viemClient.getGasPrice()
+
+  // Add 20% buffer for gas price fluctuations
+  const gasCost = (EVM_NATIVE_GAS_LIMIT * gasPrice * (100n + GAS_PRICE_BUFFER_PERCENT)) / 100n
+
+  const balanceBigInt = BigInt(balance)
+
+  if (balanceBigInt <= gasCost) {
+    throw new Error(
+      `Insufficient balance to cover gas. Need ${fromBaseUnit(gasCost.toString(), asset.precision)} ${asset.symbol} for gas.`
+    )
+  }
+
+  const maxSend = balanceBigInt - gasCost
+
+  return fromBaseUnit(maxSend.toString(), asset.precision)
+}
+
+async function calculateMaxSolanaSend(asset: Asset, balance: string, from: string, recipient: string): Promise<string> {
+  const isNative = isNativeToken(asset)
+
+  if (isNative) {
+    // SOL: Reserve rent-exempt + transaction fee
+    const balanceBigInt = BigInt(balance)
+    const requiredReserve = SOLANA_RENT_EXEMPT_MINIMUM + SOLANA_BASE_FEE
+
+    if (balanceBigInt <= requiredReserve) {
+      const requiredSol = fromBaseUnit(requiredReserve.toString(), 9)
+      throw new Error(
+        `Insufficient SOL balance to cover fees and rent-exempt minimum. Need at least ${requiredSol} SOL.`
+      )
+    }
+
+    const maxSend = balanceBigInt - requiredReserve
+
+    return fromBaseUnit(maxSend.toString(), asset.precision)
+  }
+
+  // SPL Token: Check if need to create recipient ATA
+  const connection = new Connection(SOLANA_RPC_URL, 'confirmed')
+  const tokenAddress = fromAssetId(asset.assetId).assetReference
+  const tokenMint = new PublicKey(tokenAddress)
+
+  let mintAccountInfo
+  let tokenProgramId
+  let recipientATA
+  let requiredSolBalance = SOLANA_BASE_FEE
+
+  try {
+    // Detect which token program owns this mint (Token vs Token-2022)
+    mintAccountInfo = await connection.getAccountInfo(tokenMint)
+    if (!mintAccountInfo) {
+      throw new Error(`Token mint ${tokenMint.toBase58()} not found`)
+    }
+    tokenProgramId = mintAccountInfo.owner
+
+    recipientATA = getAssociatedTokenAddressSync(tokenMint, new PublicKey(recipient), false, tokenProgramId)
+
+    const accountInfo = await connection.getAccountInfo(recipientATA)
+    if (!accountInfo) {
+      requiredSolBalance += SOLANA_ATA_CREATION_COST
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('Token mint')) {
+      throw error
+    }
+    throw new Error(
+      `Unable to check token account - network error: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+
+  try {
+    // Check sender's SOL balance for fees
+    const solBalance = await connection.getBalance(new PublicKey(from))
+
+    if (BigInt(solBalance) < requiredSolBalance) {
+      const requiredSol = fromBaseUnit(requiredSolBalance.toString(), 9)
+      const ataCost = requiredSolBalance > SOLANA_BASE_FEE ? ' (including ATA creation)' : ''
+      throw new Error(`Need ${requiredSol} SOL to cover transaction fees${ataCost}`)
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('Need')) {
+      throw error
+    }
+    throw new Error(
+      `Unable to check SOL balance - network error: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+
+  // Can send full token balance
+  return fromBaseUnit(balance, asset.precision)
+}
+
+export function estimateEvmTransferGas(isNative: boolean): bigint {
+  return isNative ? EVM_NATIVE_GAS_LIMIT : EVM_ERC20_GAS_LIMIT
+}
+
+export function estimateSolanaFee(needsAtaCreation: boolean): bigint {
+  return needsAtaCreation ? SOLANA_BASE_FEE + SOLANA_ATA_CREATION_COST : SOLANA_BASE_FEE
+}
+
+export function formatEstimatedFee(chainId: string, isNative: boolean, needsAtaCreation?: boolean): string {
+  const isEvm = chainId.startsWith('eip155:')
+
+  if (isEvm) {
+    return isNative ? '~0.001' : '~0.002'
+  }
+
+  if (needsAtaCreation) {
+    return '~0.00244'
+  }
+
+  return '~0.000005'
+}

--- a/apps/agentic-server/src/utils/networkHelpers.ts
+++ b/apps/agentic-server/src/utils/networkHelpers.ts
@@ -1,0 +1,11 @@
+export const networkToFeeSymbol: Record<string, string> = {
+  ethereum: 'ETH',
+  optimism: 'ETH',
+  arbitrum: 'ETH',
+  base: 'ETH',
+  polygon: 'POL',
+  avalanche: 'AVAX',
+  bsc: 'BNB',
+  gnosis: 'xDAI',
+  solana: 'SOL',
+}

--- a/apps/agentic-server/src/utils/transactionHelpers.ts
+++ b/apps/agentic-server/src/utils/transactionHelpers.ts
@@ -1,0 +1,220 @@
+import { fromAssetId } from '@shapeshiftoss/caip'
+import type { Asset } from '@shapeshiftoss/types'
+import { toBaseUnit } from '@shapeshiftoss/utils'
+import {
+  createAssociatedTokenAccountInstruction,
+  createTransferCheckedInstruction,
+  createTransferInstruction,
+  getAssociatedTokenAddressSync,
+  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
+} from '@solana/spl-token'
+import { Connection, PublicKey, SystemProgram } from '@solana/web3.js'
+import { encodeFunctionData, erc20Abi, getAddress } from 'viem'
+
+import type { TransactionData } from '../lib/schemas/swapSchemas'
+
+export function createTransaction(tx: {
+  chainId: string | number
+  data: string
+  from: string
+  to: string
+  value: string
+  gasLimit?: string
+}): TransactionData {
+  return {
+    chainId: String(tx.chainId),
+    data: tx.data || '',
+    from: tx.from,
+    to: tx.to,
+    value: tx.value,
+    ...(tx.gasLimit && { gasLimit: tx.gasLimit }),
+  }
+}
+
+export function buildEvmNativeTransfer(asset: Asset, from: string, to: string, amount: string): TransactionData {
+  const value = toBaseUnit(amount, asset.precision)
+
+  return createTransaction({
+    chainId: asset.chainId,
+    data: '0x',
+    from: getAddress(from),
+    to: getAddress(to),
+    value,
+    gasLimit: '21000',
+  })
+}
+
+export function buildEvmTokenTransfer(asset: Asset, from: string, to: string, amount: string): TransactionData {
+  const tokenAddress = fromAssetId(asset.assetId).assetReference
+
+  const data = encodeFunctionData({
+    abi: erc20Abi,
+    functionName: 'transfer',
+    args: [getAddress(to), BigInt(toBaseUnit(amount, asset.precision))],
+  })
+
+  return createTransaction({
+    chainId: asset.chainId,
+    data,
+    from: getAddress(from),
+    to: getAddress(tokenAddress),
+    value: '0',
+    gasLimit: '65000',
+  })
+}
+
+export async function buildSolanaTransfer(
+  asset: Asset,
+  from: string,
+  to: string,
+  amount: string,
+  rpcUrl: string
+): Promise<TransactionData & { needsAtaCreation?: boolean }> {
+  const isNative = asset.assetId === 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501'
+
+  if (isNative) {
+    return buildSolanaNativeTransfer(asset, from, to, amount)
+  }
+
+  return buildSolanaSplTransfer(asset, from, to, amount, rpcUrl)
+}
+
+function buildSolanaNativeTransfer(asset: Asset, from: string, to: string, amount: string): TransactionData {
+  const instruction = SystemProgram.transfer({
+    fromPubkey: new PublicKey(from),
+    toPubkey: new PublicKey(to),
+    lamports: BigInt(toBaseUnit(amount, asset.precision)),
+  })
+
+  const data = JSON.stringify({
+    instructions: [
+      {
+        programId: instruction.programId.toBase58(),
+        keys: instruction.keys.map(key => ({
+          pubkey: key.pubkey.toBase58(),
+          isSigner: key.isSigner,
+          isWritable: key.isWritable,
+        })),
+        data: instruction.data.toString('hex'),
+      },
+    ],
+  })
+
+  return createTransaction({
+    chainId: asset.chainId,
+    data,
+    from,
+    to: '',
+    value: '0',
+  })
+}
+
+async function buildSolanaSplTransfer(
+  asset: Asset,
+  from: string,
+  to: string,
+  amount: string,
+  rpcUrl: string
+): Promise<TransactionData & { needsAtaCreation?: boolean }> {
+  const connection = new Connection(rpcUrl, 'confirmed')
+  const tokenAddress = fromAssetId(asset.assetId).assetReference
+  const tokenMint = new PublicKey(tokenAddress)
+
+  // Detect which token program owns this mint (Token vs Token-2022)
+  const mintAccountInfo = await connection.getAccountInfo(tokenMint)
+  if (!mintAccountInfo) {
+    throw new Error(`Token mint ${tokenMint.toBase58()} not found`)
+  }
+
+  const isToken2022 = mintAccountInfo.owner.toString() === TOKEN_2022_PROGRAM_ID.toString()
+  const tokenProgramId = isToken2022 ? TOKEN_2022_PROGRAM_ID : TOKEN_PROGRAM_ID
+
+  const senderATA = getAssociatedTokenAddressSync(tokenMint, new PublicKey(from), false, tokenProgramId)
+  const recipientATA = getAssociatedTokenAddressSync(tokenMint, new PublicKey(to), false, tokenProgramId)
+
+  // Check if recipient ATA exists
+  const accountInfo = await connection.getAccountInfo(recipientATA)
+  const needsAtaCreation = !accountInfo
+
+  const instructions = []
+
+  // Create recipient ATA if needed (sender pays)
+  if (needsAtaCreation) {
+    instructions.push(
+      createAssociatedTokenAccountInstruction(
+        new PublicKey(from), // Payer
+        recipientATA, // ATA address
+        new PublicKey(to), // Owner
+        tokenMint, // Mint
+        tokenProgramId // Program ID
+      )
+    )
+  }
+
+  // Add transfer instruction - different for Token-2022 vs regular SPL tokens
+  if (isToken2022) {
+    // Token-2022 requires createTransferCheckedInstruction with mint and decimals
+    // Get decimals from on-chain parsed mint data
+    const parsedMintInfo = await connection.getParsedAccountInfo(tokenMint)
+    const onChainDecimals =
+      parsedMintInfo?.value?.data &&
+      typeof parsedMintInfo.value.data === 'object' &&
+      'parsed' in parsedMintInfo.value.data
+        ? parsedMintInfo.value.data.parsed?.info?.decimals
+        : undefined
+    const decimals = typeof onChainDecimals === 'number' ? onChainDecimals : asset.precision
+
+    if (typeof onChainDecimals === 'number' && onChainDecimals !== asset.precision) {
+      console.warn(`Decimals mismatch for ${asset.symbol}: on-chain=${onChainDecimals}, metadata=${asset.precision}`)
+    }
+
+    instructions.push(
+      createTransferCheckedInstruction(
+        senderATA,
+        tokenMint, // Mint required for Token-2022
+        recipientATA,
+        new PublicKey(from), // Authority
+        BigInt(toBaseUnit(amount, decimals)),
+        decimals, // Decimals required for Token-2022
+        [],
+        tokenProgramId
+      )
+    )
+  } else {
+    // Regular SPL tokens use simpler createTransferInstruction
+    instructions.push(
+      createTransferInstruction(
+        senderATA,
+        recipientATA,
+        new PublicKey(from), // Authority
+        BigInt(toBaseUnit(amount, asset.precision)),
+        [],
+        tokenProgramId
+      )
+    )
+  }
+
+  const data = JSON.stringify({
+    instructions: instructions.map(ix => ({
+      programId: ix.programId.toBase58(),
+      keys: ix.keys.map(key => ({
+        pubkey: key.pubkey.toBase58(),
+        isSigner: key.isSigner,
+        isWritable: key.isWritable,
+      })),
+      data: ix.data.toString('hex'),
+    })),
+  })
+
+  return {
+    ...createTransaction({
+      chainId: asset.chainId,
+      data,
+      from,
+      to: '',
+      value: '0',
+    }),
+    needsAtaCreation,
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI: Added a three-step Send workflow UI with summary, stepper, loading states, masked sender, estimated fees, From/To/Amount/Network details, optional recipient account note, and tool registration.

* **Hooks**
  * Client: Added a send execution hook exposing per-step statuses, network info, errors, persistence and resumed-execution hydration.

* **Core / Server**
  * Server: Added a public send tool supporting multi-chain sends with validation, summaries, and execution.

* **Utils**
  * New helpers for executing sends, asset resolution, balance checks, fee estimation, transaction construction, network fee symbols, and address validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->