### PR TITLE
feat: make portfolio fetch one request and make LLM smart about connected accounts

### DIFF
--- a/apps/agentic-chat/src/services/portfolioService.ts
+++ b/apps/agentic-chat/src/services/portfolioService.ts
@@ -1,6 +1,5 @@
 import type { ChainId } from '@shapeshiftoss/caip'
 import type { EvmSolanaNetwork } from '@shapeshiftoss/types'
-import { EVM_NETWORKS, SOLANA_NETWORK, networkToChainIdMap } from '@shapeshiftoss/types'
 
 import { bn, bnOrZero } from '@/lib/bignumber'
 import { calculate24hDelta } from '@/lib/portfolio'
@@ -20,43 +19,14 @@ type PortfolioBalanceItem = {
   usdAmount: string
 }
 
-type PortfolioResponse = {
+type PortfolioNetworkResult = {
+  network: EvmSolanaNetwork
   account: string
   chainId: ChainId
   balances: PortfolioBalanceItem[]
 }
 
 const API_BASE_URL = import.meta.env.VITE_AGENTIC_SERVER_BASE_URL
-
-async function fetchNetworkPortfolio(
-  network: EvmSolanaNetwork,
-  evmAddress?: string,
-  solanaAddress?: string
-): Promise<PortfolioResponse | null> {
-  try {
-    const response = await fetch(`${API_BASE_URL}/api/portfolio`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        network,
-        evmAddress,
-        solanaAddress,
-      }),
-    })
-
-    if (!response.ok) {
-      console.error(`[Portfolio] Failed to fetch ${network}:`, response.statusText)
-      return null
-    }
-
-    return (await response.json()) as PortfolioResponse
-  } catch (error) {
-    console.error(`[Portfolio] Error fetching ${network}:`, error)
-    return null
-  }
-}
 
 export async function fetchFullPortfolio(evmAddress?: string, solanaAddress?: string): Promise<PortfolioData> {
   if (!evmAddress && !solanaAddress) {
@@ -65,76 +35,68 @@ export async function fetchFullPortfolio(evmAddress?: string, solanaAddress?: st
       assets: [],
       totalBalance: '0',
       delta24h: null,
-      loadingChains: new Set(),
-      errorChains: new Set(),
       lastUpdated: Date.now(),
     }
   }
 
-  const loadingChains = new Set<ChainId>()
-  const errorChains = new Set<ChainId>()
+  try {
+    const response = await fetch(`${API_BASE_URL}/api/portfolio`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ evmAddress, solanaAddress }),
+    })
 
-  const networksToFetch: EvmSolanaNetwork[] = []
-
-  if (evmAddress) {
-    networksToFetch.push(...EVM_NETWORKS)
-  }
-
-  if (solanaAddress) {
-    networksToFetch.push(SOLANA_NETWORK)
-  }
-
-  const fetchPromises = networksToFetch.map(async network => {
-    const chainId = networkToChainIdMap[network]
-    loadingChains.add(chainId)
-
-    const result = await fetchNetworkPortfolio(network, evmAddress, solanaAddress)
-
-    loadingChains.delete(chainId)
-
-    if (!result) {
-      errorChains.add(chainId)
-      return null
+    if (!response.ok) {
+      console.error('[Portfolio] Failed to fetch:', response.statusText)
+      return {
+        assets: [],
+        totalBalance: '0',
+        delta24h: null,
+        lastUpdated: Date.now(),
+      }
     }
 
-    return result
-  })
+    const results = (await response.json()) as PortfolioNetworkResult[]
 
-  const results = await Promise.all(fetchPromises)
-  const successfulResults = results.filter((r): r is PortfolioResponse => r !== null)
+    const allAssets: PortfolioAsset[] = results.flatMap(result =>
+      result.balances.map(balance => ({
+        assetId: balance.asset.assetId,
+        chainId: result.chainId,
+        name: balance.asset.name,
+        symbol: balance.asset.symbol,
+        icon: undefined,
+        cryptoBalancePrecision: balance.cryptoAmount,
+        fiatAmount: balance.usdAmount,
+        price: balance.asset.price,
+        priceChange24h: balance.asset.priceChange24h?.toString() ?? '0',
+        allocation: 0,
+      }))
+    )
 
-  const allAssets: PortfolioAsset[] = successfulResults.flatMap(result =>
-    result.balances.map(balance => ({
-      assetId: balance.asset.assetId,
-      chainId: result.chainId,
-      name: balance.asset.name,
-      symbol: balance.asset.symbol,
-      icon: undefined,
-      cryptoBalancePrecision: balance.cryptoAmount,
-      fiatAmount: balance.usdAmount,
-      price: balance.asset.price,
-      priceChange24h: balance.asset.priceChange24h?.toString() ?? '0',
-      allocation: 0,
+    const totalBalance = allAssets.reduce((sum, asset) => sum.plus(bnOrZero(asset.fiatAmount)), bn(0))
+
+    const assetsWithAllocation = allAssets.map(asset => ({
+      ...asset,
+      allocation: totalBalance.gt(0) ? bnOrZero(asset.fiatAmount).div(totalBalance).times(100).toNumber() : 0,
     }))
-  )
 
-  const totalBalance = allAssets.reduce((sum, asset) => sum.plus(bnOrZero(asset.fiatAmount)), bn(0))
+    const delta24h = calculate24hDelta(assetsWithAllocation)
 
-  const assetsWithAllocation = allAssets.map(asset => ({
-    ...asset,
-    allocation: totalBalance.gt(0) ? bnOrZero(asset.fiatAmount).div(totalBalance).times(100).toNumber() : 0,
-  }))
+    console.log(`[Portfolio] Fetched ${allAssets.length} assets across ${results.length} networks`)
 
-  const delta24h = calculate24hDelta(assetsWithAllocation)
-
-  console.log(`[Portfolio] Fetched ${allAssets.length} assets across ${successfulResults.length} chains`)
-
-  return {
-    assets: assetsWithAllocation,
-    totalBalance: totalBalance.toFixed(2),
-    delta24h,
-    loadingChains,
-    errorChains,
-    lastUpdated: Date.now(),
+    return {
+      assets: assetsWithAllocation,
+      totalBalance: totalBalance.toFixed(2),
+      delta24h,
+      lastUpdated: Date.now(),
+    }
+  } catch (error) {
+    console.error('[Portfolio] Error:', error)
+    return {
+      assets: [],
+      totalBalance: '0',
+      delta24h: null,
+      lastUpdated: Date.now(),
+    }
   }
 }

--- a/apps/agentic-chat/src/types/portfolio.ts
+++ b/apps/agentic-chat/src/types/portfolio.ts
@@ -33,7 +33,5 @@ export type PortfolioData = {
   assets: PortfolioAsset[]
   totalBalance: string
   delta24h: PortfolioDelta | null
-  loadingChains: Set<ChainId>
-  errorChains: Set<ChainId>
   lastUpdated: number
 }

--- a/apps/agentic-server/src/routes/chat.ts
+++ b/apps/agentic-server/src/routes/chat.ts
@@ -158,8 +158,21 @@ function buildTools(walletContext: WalletContext) {
   }
 }
 
-const SYSTEM_PROMPT =
-  `
+function buildConnectedWalletsPrompt(evmAddress?: string, solanaAddress?: string): string {
+  if (!evmAddress && !solanaAddress) {
+    return '**Connected Wallets:** None'
+  }
+  const parts: string[] = []
+  if (evmAddress) parts.push(`EVM (${evmAddress.slice(0, 6)}...${evmAddress.slice(-4)})`)
+  if (solanaAddress) parts.push(`Solana (${solanaAddress.slice(0, 4)}...${solanaAddress.slice(-4)})`)
+  return `**Connected Wallets:** ${parts.join(', ')}`
+}
+
+function buildSystemPrompt(evmAddress?: string, solanaAddress?: string): string {
+  return (
+    `
+${buildConnectedWalletsPrompt(evmAddress, solanaAddress)}
+
 **ShapeShift Crypto Assistant**
 
 **Current Date and Time:**
@@ -227,9 +240,12 @@ Examples:
 - If a tool fails, explain what went wrong and suggest alternatives
 
 **Portfolio Rules:**
+- Portfolio tool fetches all connected networks by default - no need to call multiple times
 - Only check balances if user says "all my [token]" or asks balance first
 - For specific amounts ("swap 10 USDC"), use exact amount without balance check
 ` + supportedChainsContext
+  )
+}
 
 export async function handleChatRequest(c: Context) {
   try {
@@ -249,7 +265,7 @@ export async function handleChatRequest(c: Context) {
     const result = streamText({
       model: anthropic('claude-haiku-4-5'),
       messages: modelMessages,
-      system: SYSTEM_PROMPT,
+      system: buildSystemPrompt(evmAddress, solanaAddress),
       temperature: 1.0,
       stopWhen: stepCountIs(5),
       tools: buildTools(walletContext),

--- a/apps/agentic-server/src/routes/portfolio.ts
+++ b/apps/agentic-server/src/routes/portfolio.ts
@@ -9,16 +9,16 @@ import {
   polygonChainId,
   solanaChainId,
 } from '@shapeshiftoss/caip'
-import { NETWORKS } from '@shapeshiftoss/types'
+import { EVM_SOLANA_NETWORKS } from '@shapeshiftoss/types'
 import type { Context } from 'hono'
 import { z } from 'zod'
 
-import { getPortfolioData } from '../tools/portfolio'
+import { getConnectedNetworks, getPortfolioData } from '../tools/portfolio'
 import type { WalletContext } from '../utils/walletContextSimple'
 
 const portfolioRequestSchema = z
   .object({
-    network: z.enum(NETWORKS),
+    networks: z.array(z.enum(EVM_SOLANA_NETWORKS)).optional(),
     evmAddress: z.string().optional(),
     solanaAddress: z.string().optional(),
   })
@@ -57,11 +57,16 @@ export async function handlePortfolioRequest(c: Context) {
   try {
     const body = await c.req.json()
     const validatedBody = portfolioRequestSchema.parse(body)
-    const { network, evmAddress, solanaAddress } = validatedBody
+    const { networks, evmAddress, solanaAddress } = validatedBody
 
     const walletContext = buildWalletContext(evmAddress, solanaAddress)
+    const networksToFetch = networks || getConnectedNetworks(walletContext)
 
-    const portfolioData = await getPortfolioData({ network }, walletContext)
+    if (networksToFetch.length === 0) {
+      return c.json({ error: 'No networks available for the provided addresses' }, 400)
+    }
+
+    const portfolioData = await getPortfolioData({ networks: networksToFetch }, walletContext)
 
     return c.json(portfolioData)
   } catch (error) {

--- a/apps/agentic-server/src/tools/portfolio.ts
+++ b/apps/agentic-server/src/tools/portfolio.ts
@@ -1,4 +1,5 @@
-import { NETWORKS, networkToChainIdMap } from '@shapeshiftoss/types'
+import type { EvmSolanaNetwork } from '@shapeshiftoss/types'
+import { chainIdToNetwork, EVM_SOLANA_NETWORKS, networkToChainIdMap } from '@shapeshiftoss/types'
 import { calculateUsdValue, fromBaseUnit } from '@shapeshiftoss/utils'
 import { z } from 'zod'
 
@@ -10,12 +11,16 @@ import { executeGetAccount } from './getAccount'
 import { executeGetAssetsBasic } from './getAssets'
 
 export const portfolioSchema = z.object({
-  network: z.enum(NETWORKS).describe('Network name (e.g., ethereum, arbitrum, solana)'),
+  networks: z
+    .array(z.enum(EVM_SOLANA_NETWORKS))
+    .optional()
+    .describe('Networks to fetch portfolio for. Omit to fetch all connected networks.'),
 })
 
 export type PortfolioInput = z.infer<typeof portfolioSchema>
 
 export type PortfolioDataFull = {
+  network: EvmSolanaNetwork
   account: string
   chainId: string
   balances: Array<{
@@ -33,7 +38,8 @@ export type PortfolioDataFull = {
   }>
 }
 
-export type PortfolioOutput = {
+export type PortfolioOutput = Array<{
+  network: EvmSolanaNetwork
   account: string
   chainId: string
   balances: Array<{
@@ -43,13 +49,19 @@ export type PortfolioOutput = {
     cryptoAmount: string
     usdAmount: string
   }>
+}>
+
+export function getConnectedNetworks(walletContext?: WalletContext): EvmSolanaNetwork[] {
+  if (!walletContext?.connectedWallets) return []
+  return Object.keys(walletContext.connectedWallets)
+    .map(chainId => chainIdToNetwork[chainId])
+    .filter((n): n is EvmSolanaNetwork => !!n && EVM_SOLANA_NETWORKS.includes(n as EvmSolanaNetwork))
 }
 
-export async function getPortfolioData(
-  input: PortfolioInput,
+async function getPortfolioDataSingle(
+  network: EvmSolanaNetwork,
   walletContext?: WalletContext
 ): Promise<PortfolioDataFull> {
-  const { network } = input
   const chainId = networkToChainIdMap[network]
   const account = getAddressForNetwork(walletContext, network)
 
@@ -68,6 +80,7 @@ export async function getPortfolioData(
   const assetMap = new Map(assets.map(asset => [asset.assetId, asset]))
 
   const result: PortfolioDataFull = {
+    network,
     account,
     chainId,
     balances: assetIds
@@ -104,27 +117,42 @@ export async function getPortfolioData(
   return result
 }
 
+export async function getPortfolioData(
+  input: { networks: EvmSolanaNetwork[] },
+  walletContext?: WalletContext
+): Promise<PortfolioDataFull[]> {
+  return Promise.all(input.networks.map(network => getPortfolioDataSingle(network, walletContext)))
+}
+
 export async function executeGetPortfolio(
   input: PortfolioInput,
   walletContext?: WalletContext
 ): Promise<PortfolioOutput> {
-  const fullData = await getPortfolioData(input, walletContext)
+  const networks = input.networks || getConnectedNetworks(walletContext)
 
-  return {
-    account: fullData.account,
-    chainId: fullData.chainId,
-    balances: fullData.balances.map(balance => ({
+  if (networks.length === 0) {
+    throw new Error('No networks specified and no connected wallets found')
+  }
+
+  const fullData = await getPortfolioData({ networks }, walletContext)
+
+  return fullData.map(networkData => ({
+    network: networkData.network,
+    account: networkData.account,
+    chainId: networkData.chainId,
+    balances: networkData.balances.map(balance => ({
       assetId: balance.asset.assetId,
       name: balance.asset.name,
       symbol: balance.asset.symbol,
       cryptoAmount: balance.cryptoAmount,
       usdAmount: balance.usdAmount,
     })),
-  }
+  }))
 }
 
 export const portfolioTool = {
-  description: 'Get user crypto balances with human-readable values and USD amounts for a specific network',
+  description:
+    'Get user crypto balances with human-readable values and USD amounts. Omit networks to fetch all connected wallets.',
   inputSchema: portfolioSchema,
   execute: executeGetPortfolio,
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified portfolio view aggregating assets and allocations across connected networks.
  * System prompts now include current date/time and connected wallet info for more contextual AI responses.
  * Portfolio queries can target multiple networks or default to all connected wallets.

* **Behavior Changes**
  * Portfolio now shows per-asset allocation and consolidated 24h delta; failures yield a safe empty portfolio state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->