### PR TITLE
fix: immer proxy revocation error in swap/send execution hooks

### DIFF
--- a/apps/agentic-chat/src/hooks/useSendExecution.ts
+++ b/apps/agentic-chat/src/hooks/useSendExecution.ts
@@ -2,6 +2,7 @@ import { useAppKitProvider } from '@reown/appkit/react'
 import type { SendOutput } from '@shapeshiftoss/agentic-server'
 import { CHAIN_NAMESPACE, fromChainId } from '@shapeshiftoss/caip'
 import type { DynamicToolUIPart } from 'ai'
+import { current } from 'immer'
 import { useEffect, useRef } from 'react'
 import { useSwitchChain } from 'wagmi'
 
@@ -237,7 +238,7 @@ export const useSendExecution = (
         setState(draft => {
           draft.error = errorMessage
           draft.failedStep = draft.currentStep
-          errorState = { ...draft }
+          errorState = current(draft)
         })
 
         if (errorState && activeConversationId) {

--- a/apps/agentic-chat/src/hooks/useSwapExecution.ts
+++ b/apps/agentic-chat/src/hooks/useSwapExecution.ts
@@ -3,6 +3,7 @@ import type { InitiateSwapOutput } from '@shapeshiftoss/agentic-server'
 import { CHAIN_NAMESPACE, fromChainId } from '@shapeshiftoss/caip'
 import { getPublicClient } from '@wagmi/core'
 import type { DynamicToolUIPart } from 'ai'
+import { current } from 'immer'
 import { useEffect, useRef } from 'react'
 import { getAddress } from 'viem'
 import { useSwitchChain } from 'wagmi'
@@ -293,7 +294,7 @@ export const useSwapExecution = (
         setState(draft => {
           draft.error = errorMessage
           draft.failedStep = draft.currentStep
-          errorState = { ...draft }
+          errorState = current(draft)
         })
 
         if (errorState && activeConversationId) {


### PR DESCRIPTION
### Problem

Users were experiencing a runtime error: `[Immer] minified error nr: 3` ("Cannot use a proxy that has been revoked").

### Root Cause

In the error handling paths of `useSwapExecution` and `useSendExecution`, the code captured the Immer draft state using a shallow spread (`{ ...draft }`). The `completedSteps` Set remained as an Immer proxy, which gets revoked after `produce()` finishes. Accessing this revoked proxy in `swapStateToPersistedState()` / `sendStateToPersistedState()` caused the error.

### Solution

Use Immer's `current()` function to safely extract a deep, non-proxy snapshot of the draft state before using it outside the producer callback.

### Changes

- `useSwapExecution.ts`: Import `current` from Immer and use it to snapshot error state
- `useSendExecution.ts`: Import `current` from Immer and use it to snapshot error state

### Sentry Issue

https://shapeshift-dao.sentry.io/share/issue/33fa363746374aa6bf60e5141b2c3e12/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error state handling in execution hooks to enhance code reliability and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->