### PR TITLE
chore: gitignore Nx cache and workspace-data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,7 @@ Thumbs.db
 
 # Playwright MCP
 .playwright-mcp
+
+# Nx — local machine cache (agents/CI should never commit these)
+.nx/cache
+.nx/workspace-data


### PR DESCRIPTION
Get nx cache to stop spewing commit lines. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated gitignore configuration to exclude local cache directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->