### PR TITLE
chore: allow shapeshift.com subdomains and any localhost in cors

### DIFF
--- a/apps/agentic-server/src/server.ts
+++ b/apps/agentic-server/src/server.ts
@@ -25,23 +25,18 @@ try {
 
 const app = new Hono()
 
-// Enable CORS for all routes
+// Allow any localhost host with optional subdomains and port
+const LOCALHOST_ORIGIN_REGEX = /^https?:\/\/([\w-]+\.)*localhost(:\d+)?$/i
+
+// Allow shapeshift.com and any subdomain at arbitrary depth
+const SHAPESHIFT_ORIGIN_REGEX = /^https:\/\/([\w-]+\.)*shapeshift\.com$/i
+
+const isAllowedOrigin = (origin: string) => LOCALHOST_ORIGIN_REGEX.test(origin) || SHAPESHIFT_ORIGIN_REGEX.test(origin)
+
 app.use(
   '/*',
   cors({
-    origin: [
-      // Local development
-      'http://localhost:3000',
-      'http://localhost:4200',
-      'http://localhost:5173',
-      // ShapeShift Web deployments
-      'https://app.shapeshift.com',
-      'https://develop.shapeshift.com',
-      'https://private.shapeshift.com',
-      // Agentic Chat deployments
-      'https://shapeshift-agentic.vercel.app',
-      'https://agent.shapeshift.com',
-    ],
+    origin: origin => (isAllowedOrigin(origin) ? origin : null),
     credentials: true,
   })
 )


### PR DESCRIPTION
## Summary
- Replace the hardcoded CORS origin allowlist in `apps/agentic-server/src/server.ts` with regex matchers
- Any `shapeshift.com` subdomain at arbitrary depth is now accepted (e.g. `app.shapeshift.com`, `dashboard.revenue.shapeshift.com`, `dev-dashboard.revenue.shapeshift.com`)
- Any `localhost` host with optional subdomains/port is now accepted (e.g. `http://localhost:3000`, `http://web.localhost:1335`)
- Drops the now-unused Vercel preview origin

## Test plan
- [ ] Hit `/api/chat` from `https://app.shapeshift.com` and confirm `Access-Control-Allow-Origin` echoes back
- [ ] Hit `/api/chat` from a multi-level subdomain (e.g. `https://dashboard.revenue.shapeshift.com`) and confirm it's allowed
- [ ] Hit `/api/chat` from `http://web.localhost:1335` and confirm it's allowed
- [ ] Hit `/api/chat` from a spoof origin like `https://evil-shapeshift.com` and confirm the CORS header is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced server origin configuration to improve compatibility with development environments and support for application subdomains while maintaining security standards.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shapeshift/agentic-chat/pull/253)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->