### PR TITLE
chore: adding rounder feelings and edges

### DIFF
--- a/apps/agentic-chat/src/components/Composer.tsx
+++ b/apps/agentic-chat/src/components/Composer.tsx
@@ -55,7 +55,7 @@ export function Composer() {
         onKeyDown={onKeyDown}
         placeholder="Write a message..."
         rows={1}
-        className="flex-1 resize-none rounded-lg border border-border bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+        className="flex-1 resize-none rounded-2xl border border-border bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
         style={
           {
             minHeight: '48px',

--- a/apps/agentic-chat/src/styles.css
+++ b/apps/agentic-chat/src/styles.css
@@ -72,7 +72,7 @@
 }
 
 :root {
-  --radius: 0.5rem;
+  --radius: 0.75rem;
   --background: oklch(1 0 0);
   --foreground: oklch(0.141 0.005 285.823);
   --card: oklch(1 0 0);


### PR DESCRIPTION
closes #242 

  ## Summary

  - Increases global `--radius` CSS variable from `0.5rem` to `0.75rem`
  - Rounds the Composer textarea from `rounded-lg` to `rounded-2xl` for a softer, more modern feel

  ## Test plan

  - [x] Verify composer textarea appears more rounded
  - [x] Spot-check cards, buttons, and other components that inherit `--radius` for visual consistency <-- on epic testing
  - [x] No layout breaks at narrow/wide viewport widths

<img width="203" height="66" alt="Screenshot 2026-05-12 at 9 40 16 PM" src="https://github.com/user-attachments/assets/e8bc71ef-e9b0-4ac6-8054-54ed048bce86" />
<img width="740" height="98" alt="Screenshot 2026-05-12 at 9 40 07 PM" src="https://github.com/user-attachments/assets/0f9fe58c-c37a-4c0f-b28f-e96c5bd48ac9" />


  Built with Claude b/c cursor went nuts. 